### PR TITLE
Exports to allow axis formatters

### DIFF
--- a/charts_common/lib/common.dart
+++ b/charts_common/lib/common.dart
@@ -41,6 +41,26 @@ export 'src/chart/cartesian/axis/axis.dart'
         NumericAxis,
         OrdinalAxis,
         OrdinalViewport;
+export 'src/chart/cartesian/axis/scale.dart'
+    show
+        Scale,
+        Extents,
+        ScaleOutputExtent,
+        RangeBandType,
+        RangeBandConfig,
+        StepSizeType,
+        StepSizeConfig,
+        MutableScale;
+export 'src/chart/cartesian/axis/tick_provider.dart'
+    show
+        TickProvider,
+        BaseTickProvider;
+export 'src/chart/cartesian/axis/tick_formatter.dart'
+    show
+        TickFormatter,
+        NumericTickFormatter,
+        OrdinalTickFormatter,
+        SimpleTickFormatterBase;
 export 'src/chart/cartesian/axis/draw_strategy/gridline_draw_strategy.dart'
     show GridlineRendererSpec;
 export 'src/chart/cartesian/axis/draw_strategy/none_draw_strategy.dart'


### PR DESCRIPTION
Add in exports to allow for writing different type of axis formatters, writing a duration axis formatter and don't want to copy all the code.